### PR TITLE
Issue 2: Add parameter for the number of cores

### DIFF
--- a/ilpexp.py
+++ b/ilpexp.py
@@ -6,14 +6,18 @@ import argparse
 
 PARSER = argparse.ArgumentParser(description='ILP Experimentation Framework')
 PARSER.add_argument('experiment', type=str, default='default', help = 'The name of the experiment to run. Must be defined in experiment.py. Input is uppercased before comparing.')
+PARSER.add_argument('--threads', type=int, default=-1, help='Number of concurrent threads to run. Defaults to half the number of cpus if not specified.')
 
 if __name__ == '__main__':
-    runner = SimpleRunner()
     
     args = PARSER.parse_args()
     
     experiment_name = args.experiment.upper()
     experiment_vars = vars(experiment)
+
+    num_threads = args.threads if args.threads > 0 else None
+    
+    runner = SimpleRunner(num_threads = num_threads)
 
     if experiment_name not in experiment_vars:
         raise(Exception(f"No experiment named {experiment_name} found in experiment.py"))


### PR DESCRIPTION
Resolves issue 2. Added a command line option --threads which
allows the user to specify the number of concurrent threads to
use in the SimpleRunner. Note that this will probably be ignored
for any other runner we implement.

Also fixes the default to be cpu_count/2. This was the original
intention so that the experiment doesn't monopolize all the
resources on the machine.